### PR TITLE
Add pending option and more payment types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export type APayPaymentStatusType = number
 export interface APayPaymentSummaryItemType {
   label: string
   amount: string
+  type: string
 }
 
 export interface APayRequestDataType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export type APayPaymentStatusType = number
 export interface APayPaymentSummaryItemType {
   label: string
   amount: string
-  type: string
+  pending: boolean
 }
 
 export interface APayRequestDataType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export type APayPaymentStatusType = number
 export interface APayPaymentSummaryItemType {
   label: string
   amount: string
-  pending: boolean
+  pending?: boolean
 }
 
 export interface APayRequestDataType {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-export type APayAllowedCardNetworkType = "amex" | "mastercard"| "visa" | "privatelabel" | "chinaunionpay" | "interac" | "jcb" | "suica" | "cartebancaires" | "idcredit" | "quicpay" | "maestro"
+export type APayAllowedCardNetworkType = "amex" | "masterCard"| "visa" | "privatelabel" | "chinaUnionPay" | "interac" | "jcb" | "suica" | "cartebancaires" | "idcredit" | "quicpay" | "maestro" | "discover" | "cartesBancaires" | "eftpos" | "electron" | "elo" | "girocard" | "mada" | "mir" | "vPay"
 
 export type APayPaymentStatusType = number
 

--- a/ios/RNApplePay.h
+++ b/ios/RNApplePay.h
@@ -1,10 +1,6 @@
 @import PassKit;
 
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface RNApplePay : NSObject <RCTBridgeModule, PKPaymentAuthorizationViewControllerDelegate>
 

--- a/ios/RNApplePay.m
+++ b/ios/RNApplePay.m
@@ -61,17 +61,17 @@ RCT_EXPORT_METHOD(complete:(NSNumber *_Nonnull)status promiseWithResolver:(RCTPr
     
     if (@available(iOS 8, *)) {
         [supportedNetworksMapping setObject:PKPaymentNetworkAmex forKey:@"amex"];
-        [supportedNetworksMapping setObject:PKPaymentNetworkMasterCard forKey:@"mastercard"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkMasterCard forKey:@"masterCard"];
         [supportedNetworksMapping setObject:PKPaymentNetworkVisa forKey:@"visa"];
     }
     
     if (@available(iOS 9, *)) {
         [supportedNetworksMapping setObject:PKPaymentNetworkDiscover forKey:@"discover"];
-        [supportedNetworksMapping setObject:PKPaymentNetworkPrivateLabel forKey:@"privatelabel"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkPrivateLabel forKey:@"privateLabel"];
     }
     
     if (@available(iOS 9.2, *)) {
-        [supportedNetworksMapping setObject:PKPaymentNetworkChinaUnionPay forKey:@"chinaunionpay"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkChinaUnionPay forKey:@"chinaUnionPay"];
         [supportedNetworksMapping setObject:PKPaymentNetworkInterac forKey:@"interac"];
     }
     
@@ -81,23 +81,35 @@ RCT_EXPORT_METHOD(complete:(NSNumber *_Nonnull)status promiseWithResolver:(RCTPr
     }
     
     if (@available(iOS 10.3, *)) {
-        [supportedNetworksMapping setObject:PKPaymentNetworkCarteBancaire forKey:@"cartebancaires"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkCarteBancaires forKey:@"carteBancaires"];
         [supportedNetworksMapping setObject:PKPaymentNetworkIDCredit forKey:@"idcredit"];
         [supportedNetworksMapping setObject:PKPaymentNetworkQuicPay forKey:@"quicpay"];
     }
     
     if (@available(iOS 11.0, *)) {
-        [supportedNetworksMapping setObject:PKPaymentNetworkCarteBancaires forKey:@"cartebancaires"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkCartesBancaires forKey:@"cartesBancaires"];
     }
     
     if (@available(iOS 12.0, *)) {
         [supportedNetworksMapping setObject:PKPaymentNetworkMaestro forKey:@"maestro"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkEftpos forKey:@"eftpos"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkElectron forKey:@"electron"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkVPay forKey:@"vPay"];
+    }
+    
+    if (@available(iOS 15.0, *)) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkElo forKey:@"elo"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkGirocard forKey:@"girocard"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkMada forKey:@"mada"];
+        [supportedNetworksMapping setObject:PKPaymentNetworkMir forKey:@"mir"];
     }
     
     NSArray *supportedNetworksProp = props[@"supportedNetworks"];
     NSMutableArray *supportedNetworks = [NSMutableArray array];
     for (NSString *supportedNetwork in supportedNetworksProp) {
-        [supportedNetworks addObject: supportedNetworksMapping[supportedNetwork]];
+        if ([supportedNetworksMapping objectForKey: supportedNetwork]) {
+            [supportedNetworks addObject: supportedNetworksMapping[supportedNetwork]];
+        }
     }
     
     return supportedNetworks;

--- a/ios/RNApplePay.m
+++ b/ios/RNApplePay.m
@@ -111,8 +111,9 @@ RCT_EXPORT_METHOD(complete:(NSNumber *_Nonnull)status promiseWithResolver:(RCTPr
     if (displayItems.count > 0) {
         for (NSDictionary *displayItem in displayItems) {
             NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:displayItem[@"amount"]];
+            NSString *type = displayItem[@"type"];
             NSString *label = displayItem[@"label"];
-            [paymentSummaryItems addObject: [PKPaymentSummaryItem summaryItemWithLabel:label amount:amount]];
+            [paymentSummaryItems addObject: [PKPaymentSummaryItem summaryItemWithLabel:label amount:amount type:type]];
         }
     }
     

--- a/ios/RNApplePay.m
+++ b/ios/RNApplePay.m
@@ -111,7 +111,8 @@ RCT_EXPORT_METHOD(complete:(NSNumber *_Nonnull)status promiseWithResolver:(RCTPr
     if (displayItems.count > 0) {
         for (NSDictionary *displayItem in displayItems) {
             NSDecimalNumber *amount = [NSDecimalNumber decimalNumberWithString:displayItem[@"amount"]];
-            NSString *type = displayItem[@"type"];
+            NSString *pending = displayItem[@"pending"];
+            PKPaymentSummaryItemType *type = (pending ? PKPaymentSummaryItemTypePending : PKPaymentSummaryItemTypeFinal);
             NSString *label = displayItem[@"label"];
             [paymentSummaryItems addObject: [PKPaymentSummaryItem summaryItemWithLabel:label amount:amount type:type]];
         }


### PR DESCRIPTION
Be able to mark the payment as pending when the amount hasn't been decided yet.
Match the type of payment types to the Apple documentation, keep casing consistent to the Apple doc as well.